### PR TITLE
Elimina la dependencia "react-native-icons" de package.json y package…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.2",
         "react-native-gesture-handler": "~2.24.0",
-        "react-native-icons": "^0.7.1",
         "react-native-mmkv": "^3.2.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -11021,11 +11020,6 @@
         "react": "*",
         "react-native": "*"
       }
-    },
-    "node_modules/react-native-icons": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/react-native-icons/-/react-native-icons-0.7.1.tgz",
-      "integrity": "sha512-UigJh4CQ+NmRThGm/7MlkdCnuR0u3Bx3EO60gKCDNeMGM6X+vfYMVUXnruefJ5SrcSguQhkFLSS0oPm9B4+FDg=="
     },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-icons": "^0.7.1",
     "react-native-mmkv": "^3.2.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",


### PR DESCRIPTION
…-lock.json para optimizar el proyecto.